### PR TITLE
[3] Add context loading tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 out
 *.swp
+test/scetch.c

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,32 @@
-SRC_LENIENT := $(shell find ./lenient -name "*.c")
+SRC_LENIENT := $(wildcard lenient/src/*.c)
+SRC_LENIENT_WITHOUT_MAIN := $(filter-out lenient/src/main.c,$(SRC_LENIENT))
 INCLUDE_LENIENT := -Ilenient/include
+
+SRC_TEST := \
+	$(SRC_LENIENT_WITHOUT_MAIN) \
+	$(shell find ./test -name "*.c")
+INCLUDE_TEST := $(INCLUDE_LENIENT)
+
+LDFLAGS :=
+LDFLAGS_TEST := $(LDFLAGS) -lcriterion
 
 out:
 	mkdir out
 
+# If libcriterion shared object file is not found, try running
+# `sudo /sbin/ldconfig`. Config of the executable should be found from:
+# /etc/ld.so.conf
+test: out/utest
+	$<
+
+out/utest: $(SRC_TEST) out
+	$(CC) $(INCLUDE_TEST) $(SRC_TEST) $(LDFLAGS_TEST) -o $@
+
 out/lenient: $(SRC_LENIENT) out
-	gcc $(INCLUDE_LENIENT) $(SRC_LENIENT) -o $@
+	$(CC) $(INCLUDE_LENIENT) $(SRC_LENIENT) -o $@
 
 out/lenient_invalid_private_access: $(SRC_LENIENT) out
-	gcc -DINVALID_ACCESS_TO_PRIVATE_DATA=1 $(INCLUDE_LENIENT) $(SRC_LENIENT) -o $@
+	$(CC) -DINVALID_ACCESS_TO_PRIVATE_DATA=1 $(INCLUDE_LENIENT) $(SRC_LENIENT) -o $@
 
 out/lenient_memory_error_detector: $(SRC_LENIENT) out
-	gcc $(INCLUDE_LENIENT) -fsanitize=address $(SRC_LENIENT) -o $@
+	$(CC) $(INCLUDE_LENIENT) -fsanitize=address $(SRC_LENIENT) -o $@

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,10 @@ INCLUDE_LENIENT := -Ilenient/include
 
 SRC_TEST := \
 	$(SRC_LENIENT_WITHOUT_MAIN) \
-	$(shell find ./test -name "*.c")
+	$(filter-out test/scetch.c,$(shell find test -name "*.c"))
+SRC_TEST_SCETCH := \
+	$(SRC_LENIENT_WITHOUT_MAIN) \
+	test/scetch.c
 INCLUDE_TEST := $(INCLUDE_LENIENT)
 
 LDFLAGS :=
@@ -18,6 +21,15 @@ out:
 # /etc/ld.so.conf
 test: out/utest
 	$<
+
+# A target for scetching test implementation. You can write a test scetch to
+# test/scetch.c. The program can be debugged and signals are not hidden by
+# Criterion test suite.
+scetch: out/scetch
+	$<
+
+out/scetch: $(SRC_TEST_SCETCH) out
+	$(CC) -g $(INCLUDE_TEST) $(SRC_TEST_SCETCH) -o $@
 
 out/utest: $(SRC_TEST) out
 	$(CC) $(INCLUDE_TEST) $(SRC_TEST) $(LDFLAGS_TEST) -o $@

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ INCLUDE_LENIENT := -Ilenient/include
 
 SRC_TEST := \
 	$(SRC_LENIENT_WITHOUT_MAIN) \
-	$(filter-out test/scetch.c,$(shell find test -name "*.c"))
+	$(filter-out test/scetch.c,$(wildcard test/*.c))
 SRC_TEST_SCETCH := \
 	$(SRC_LENIENT_WITHOUT_MAIN) \
 	test/scetch.c

--- a/lenient/include/module.h
+++ b/lenient/include/module.h
@@ -18,8 +18,6 @@
  * To have visibility to static `this_public` and `this_private` of any module
  * during compilation, 'module context' function definitions are placed behind
  * macros.
- *
- * TODO [#3] implement tests.
  */
 
 #ifndef MODULE_H_DEFINED

--- a/lenient/include/module.h
+++ b/lenient/include/module.h
@@ -46,31 +46,31 @@
 /*
  * Returns -1 on error and 0 on success.
  */
-#define MODULE_GENERATE_LOAD_CONTEXT(struct_public, struct_full)           \
-static int32_t                                                             \
-module_load_context(struct_public* new_this)                               \
-{                                                                          \
-    if (NULL != this_public || NULL != this_private) {                     \
-        fprintf(stderr, "Previous module context has not been unloaded."); \
-        return -1;                                                         \
-    }                                                                      \
-                                                                           \
-    if (NULL == new_this) {                                                \
-        fprintf(stderr, "Module context load received a null pointer.");   \
-        return -1;                                                         \
-    }                                                                      \
-                                                                           \
-    if (&(((struct_full*) new_this)->public) != new_this) {                \
-        fprintf(                                                           \
-            stderr,                                                        \
-            "Module context load received an unrecognized pointer.");      \
-        return -1;                                                         \
-    }                                                                      \
-                                                                           \
-    this_public = new_this;                                                \
-    this_private = &(((struct_full*) new_this)->private);                  \
-                                                                           \
-    return 0;                                                              \
+#define MODULE_GENERATE_LOAD_CONTEXT(struct_public, struct_full)             \
+static int32_t                                                               \
+module_load_context(struct_public* new_this)                                 \
+{                                                                            \
+    if (NULL != this_public || NULL != this_private) {                       \
+        fprintf(stderr, "Previous module context has not been unloaded.\n"); \
+        return -1;                                                           \
+    }                                                                        \
+                                                                             \
+    if (NULL == new_this) {                                                  \
+        fprintf(stderr, "Module context load received a null pointer.\n");   \
+        return -1;                                                           \
+    }                                                                        \
+                                                                             \
+    if (&(((struct_full*) new_this)->public) != new_this) {                  \
+        fprintf(                                                             \
+            stderr,                                                          \
+            "Module context load received an unrecognized pointer.\n");      \
+        return -1;                                                           \
+    }                                                                        \
+                                                                             \
+    this_public = new_this;                                                  \
+    this_private = &(((struct_full*) new_this)->private);                    \
+                                                                             \
+    return 0;                                                                \
 }
 
 #define MODULE_GENERATE_UNLOAD_CONTEXT \
@@ -83,32 +83,33 @@ module_unload_context(void)            \
 
 // TODO document the return values and consider returning true, when context
 // loaded. Now returning 0 as in no error. Then fix the tests.
-#define MODULE_GENERATE_VALIDATE_CONTEXT_LOADED \
-static int32_t                                  \
-module_validate_context_loaded(void)            \
-{                                               \
-    if (NULL == this_public) {                  \
-        fprintf(stderr, "NULL public this.");   \
-        return -1;                              \
-    }                                           \
-                                                \
-    if (NULL == this_private) {                 \
-        fprintf(stderr, "NULL private this.");  \
-        return -1;                              \
-    }                                           \
-                                                \
-    return 0;                                   \
+#define MODULE_GENERATE_VALIDATE_CONTEXT_LOADED   \
+static int32_t                                    \
+module_validate_context_loaded(void)              \
+{                                                 \
+    if (NULL == this_public) {                    \
+        fprintf(stderr, "NULL public this.\n");   \
+        return -1;                                \
+    }                                             \
+                                                  \
+    if (NULL == this_private) {                   \
+        fprintf(stderr, "NULL private this.\n");  \
+        return -1;                                \
+    }                                             \
+                                                  \
+    return 0;                                     \
 }
 
-// TODO to allow testing, consider if a signal can be fired instead of exiting
-#define MODULE_GENERATE_EXIT_ON_UNLOADED_CONTEXT         \
-static void                                              \
-module_exit_on_unloaded_context(void)                    \
-{                                                        \
-    if (0 != module_validate_context_loaded()) {         \
-        fprintf(stderr, "Exiting on unloaded context."); \
-        exit(1);                                         \
-    }                                                    \
+// TODO [#20] To allow testing, consider if a signal can be fired instead of
+// exiting.
+#define MODULE_GENERATE_EXIT_ON_UNLOADED_CONTEXT           \
+static void                                                \
+module_exit_on_unloaded_context(void)                      \
+{                                                          \
+    if (0 != module_validate_context_loaded()) {           \
+        fprintf(stderr, "Exiting on unloaded context.\n"); \
+        exit(1);                                           \
+    }                                                      \
 }
 
 #endif // MODULE_H_DEFINED

--- a/lenient/include/module.h
+++ b/lenient/include/module.h
@@ -27,6 +27,8 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
 
 #define MODULE_GENERATE_CONTEXT_FUNCTIONS(struct_public, struct_full) \
     MODULE_GENERATE_DECLARATIONS(struct_public)                       \

--- a/lenient/include/module.h
+++ b/lenient/include/module.h
@@ -81,6 +81,8 @@ module_unload_context(void)            \
     this_private = NULL;               \
 }
 
+// TODO document the return values and consider returning true, when context
+// loaded. Now returning 0 as in no error. Then fix the tests.
 #define MODULE_GENERATE_VALIDATE_CONTEXT_LOADED \
 static int32_t                                  \
 module_validate_context_loaded(void)            \
@@ -98,6 +100,7 @@ module_validate_context_loaded(void)            \
     return 0;                                   \
 }
 
+// TODO to allow testing, consider if a signal can be fired instead of exiting
 #define MODULE_GENERATE_EXIT_ON_UNLOADED_CONTEXT         \
 static void                                              \
 module_exit_on_unloaded_context(void)                    \

--- a/lenient/include/module.h
+++ b/lenient/include/module.h
@@ -103,7 +103,7 @@ module_is_context_loaded(void)                    \
 static void                                                \
 module_exit_on_unloaded_context(void)                      \
 {                                                          \
-    if (0 != module_is_context_loaded()) {                 \
+    if (0 == module_is_context_loaded()) {                 \
         fprintf(stderr, "Exiting on unloaded context.\n"); \
         exit(1);                                           \
     }                                                      \

--- a/lenient/include/module.h
+++ b/lenient/include/module.h
@@ -10,8 +10,8 @@
  * Each function utilizing `this_public` or `this_private` should first call
  * `module_load_context()` before use of the variables and finish by calling
  * `module_unload_context()` when done using the variables.
- * `module_is_context_loaded()` and `module_exit_on_unloaded_context()`
- * are provided for sanity checking that a context is actually loaded and as an
+ * `module_is_context_loaded()` and `module_exit_on_unloaded_context()` are
+ * provided for sanity checking that a context is actually loaded and as an
  * example can be utilized in internal functions if a file provides exposed
  * functions calling to internal functions.
  *

--- a/lenient/include/module.h
+++ b/lenient/include/module.h
@@ -103,7 +103,7 @@ module_is_context_loaded(void)                    \
 static void                                                \
 module_exit_on_unloaded_context(void)                      \
 {                                                          \
-    if (0 == module_is_context_loaded()) {                 \
+    if ( ! module_is_context_loaded()) {                 \
         fprintf(stderr, "Exiting on unloaded context.\n"); \
         exit(1);                                           \
     }                                                      \

--- a/lenient/include/module_wrapper.h
+++ b/lenient/include/module_wrapper.h
@@ -1,6 +1,8 @@
 #ifndef MODULE_WRAPPER_H_DEFINED
 #define MODULE_WRAPPER_H_DEFINED
 
+#include <stdint.h>
+
 struct module_wrapper {
     int exposed;
 };

--- a/lenient/include/module_wrapper.h
+++ b/lenient/include/module_wrapper.h
@@ -29,7 +29,7 @@ void
 module_wrapper_unload_context(void);
 
 int32_t
-module_wrapper_validate_context_loaded(void);
+module_wrapper_is_context_loaded(void);
 
 void
 module_wrapper_exit_on_unloaded_context(void);

--- a/lenient/include/module_wrapper.h
+++ b/lenient/include/module_wrapper.h
@@ -1,0 +1,35 @@
+#ifndef MODULE_WRAPPER_H_DEFINED
+#define MODULE_WRAPPER_H_DEFINED
+
+struct module_wrapper {
+    int exposed;
+};
+
+struct module_wrapper_private {
+    int hidden;
+};
+
+struct module_wrapper_full {
+    struct module_wrapper public;
+    struct module_wrapper_private private;
+};
+
+struct module_wrapper*
+module_wrapper_construct_to_heap(int _exposed, int _hidden);
+
+void
+module_wrapper_destroy(struct module_wrapper* target_public);
+
+int32_t
+module_wrapper_load_context(struct module_wrapper* new_this);
+
+void
+module_wrapper_unload_context(void);
+
+int32_t
+module_wrapper_validate_context_loaded(void);
+
+void
+module_wrapper_exit_on_unloaded_context(void);
+
+#endif // MODULE_WRAPPER_H_DEFINED

--- a/lenient/src/demo.c
+++ b/lenient/src/demo.c
@@ -27,8 +27,9 @@ demo_construct_to_heap(int _foo)
     struct demo* instance_public;
     struct demo_private* instance_private;
 
-    // TODO initialize remaining local variables to NULL
     instance_full = NULL;
+    instance_public = NULL;
+    instance_private = NULL;
 
     /*
      * Allocate memory for module instance, containing both public and private

--- a/lenient/src/demo.c
+++ b/lenient/src/demo.c
@@ -144,12 +144,12 @@ demo_add_to_foo_recoverable(
 static int
 add_to_foo_recoverable(int operand, int* result)
 {
-    int err;
+    int is_loaded;
 
-    err = 0;
+    is_loaded = -1;
 
-    err = module_is_context_loaded();
-    if (0 != err) {
+    is_loaded = module_is_context_loaded();
+    if (0 == is_loaded) {
         fprintf(stderr, "Module context is not loaded while adding to foo\n");
         return -1;
     }

--- a/lenient/src/demo.c
+++ b/lenient/src/demo.c
@@ -148,7 +148,7 @@ add_to_foo_recoverable(int operand, int* result)
 
     err = 0;
 
-    err = module_validate_context_loaded();
+    err = module_is_context_loaded();
     if (0 != err) {
         fprintf(stderr, "Module context is not loaded while adding to foo\n");
         return -1;

--- a/lenient/src/demo.c
+++ b/lenient/src/demo.c
@@ -27,6 +27,7 @@ demo_construct_to_heap(int _foo)
     struct demo* instance_public;
     struct demo_private* instance_private;
 
+    // TODO initialize remaining local variables to NULL
     instance_full = NULL;
 
     /*

--- a/lenient/src/demo.c
+++ b/lenient/src/demo.c
@@ -149,7 +149,7 @@ add_to_foo_recoverable(int operand, int* result)
     is_loaded = -1;
 
     is_loaded = module_is_context_loaded();
-    if (0 == is_loaded) {
+    if ( ! is_loaded) {
         fprintf(stderr, "Module context is not loaded while adding to foo\n");
         return -1;
     }

--- a/lenient/src/module_wrapper.c
+++ b/lenient/src/module_wrapper.c
@@ -70,9 +70,9 @@ module_wrapper_unload_context(void)
 }
 
 int32_t
-module_wrapper_validate_context_loaded(void)
+module_wrapper_is_context_loaded(void)
 {
-    return module_validate_context_loaded();
+    return module_is_context_loaded();
 }
 
 void

--- a/lenient/src/module_wrapper.c
+++ b/lenient/src/module_wrapper.c
@@ -1,0 +1,81 @@
+#include "module.h"
+#include "module_wrapper.h"
+
+// Module context begin
+static struct module_wrapper* this_public;
+static struct module_wrapper_private* this_private;
+// Module context end
+
+MODULE_GENERATE_CONTEXT_FUNCTIONS(struct module_wrapper, struct module_wrapper_full)
+
+struct module_wrapper*
+module_wrapper_construct_to_heap(int _exposed, int _hidden)
+{
+    struct module_wrapper_full* instance_full;
+    struct module_wrapper* instance_public;
+    struct module_wrapper_private* instance_private;
+
+    instance_full = NULL;
+    instance_public = NULL;
+    instance_private = NULL;
+
+    instance_full = calloc(1, sizeof(struct module_wrapper_full));
+    if (NULL == instance_full) {
+        fprintf(stderr,
+            "Failed to allocate memory for full module wrapper instance.");
+        return NULL;
+    }
+
+    instance_public = &(instance_full->public);
+    instance_private = &(instance_full->private);
+
+    instance_public->exposed = _exposed;
+    instance_private->hidden = _hidden;
+
+    if ((void*) instance_full != (void*) instance_public) {
+        fprintf(stderr,
+            "Unexpected memory address for public field of module.\n");
+        free(instance_full);
+        instance_full = NULL;
+        instance_public = NULL;
+        instance_private = NULL;
+        return NULL;
+    }
+
+    return instance_public;
+}
+
+void
+module_wrapper_destroy(struct module_wrapper* target_public)
+{
+    struct module_wrapper_full* target =
+        (struct module_wrapper_full*) target_public;
+
+    free(target);
+    target = NULL;
+    target_public = NULL;
+}
+
+int32_t
+module_wrapper_load_context(struct module_wrapper* new_this)
+{
+    return module_load_context(new_this);
+}
+
+void
+module_wrapper_unload_context(void)
+{
+    module_unload_context();
+}
+
+int32_t
+module_wrapper_validate_context_loaded(void)
+{
+    return module_validate_context_loaded();
+}
+
+void
+module_wrapper_exit_on_unloaded_context(void)
+{
+    module_exit_on_unloaded_context();
+}

--- a/lenient/src/module_wrapper.c
+++ b/lenient/src/module_wrapper.c
@@ -34,7 +34,7 @@ module_wrapper_construct_to_heap(int _exposed, int _hidden)
 
     if ((void*) instance_full != (void*) instance_public) {
         fprintf(stderr,
-            "Unexpected memory address for public field of module.\n");
+            "Unexpected memory address for public field of module instance.\n");
         free(instance_full);
         instance_full = NULL;
         instance_public = NULL;
@@ -48,8 +48,9 @@ module_wrapper_construct_to_heap(int _exposed, int _hidden)
 void
 module_wrapper_destroy(struct module_wrapper* target_public)
 {
-    struct module_wrapper_full* target =
-        (struct module_wrapper_full*) target_public;
+    struct module_wrapper_full* target;
+
+    target = (struct module_wrapper_full*) target_public;
 
     free(target);
     target = NULL;

--- a/scripts/install_build_dependencies.sh
+++ b/scripts/install_build_dependencies.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -e
+
+readonly DEPENDENCIES_INSTALL_WORKAREA='/tmp/c-encapsulation/dependencies-install'
+
+main() {
+    local -r file_criterion_compressed='criterion-v2.3.3-linux-x86_64.tar.bz2'
+
+    if [ ! -d "${DEPENDENCIES_INSTALL_WORKAREA}" ] ; then
+        mkdir -p ${DEPENDENCIES_INSTALL_WORKAREA}
+    fi
+
+    pushd ${DEPENDENCIES_INSTALL_WORKAREA}
+
+    wget https://github.com/Snaipe/Criterion/releases/download/v2.3.3/${file_criterion_compressed}
+    tar -xjvf ${file_criterion_compressed}
+
+    pushd criterion-v2.3.3
+    echo "Copying headers and library under /usr/local/"
+    sudo cp --verbose --recursive include/criterion /usr/local/include/
+    sudo cp --verbose lib/libcriterion* /usr/local/lib/
+    popd # criterion-v2.3.3
+
+    popd # ${DEPENDENCIES_INSTALL_WORKAREA}
+
+    rm --verbose --recursive ${DEPENDENCIES_INSTALL_WORKAREA}
+}
+
+main "${@}"

--- a/scripts/install_build_dependencies.sh
+++ b/scripts/install_build_dependencies.sh
@@ -5,7 +5,7 @@ set -e
 readonly DEPENDENCIES_INSTALL_WORKAREA='/tmp/c-encapsulation/dependencies-install'
 
 main() {
-    local -r file_criterion_compressed='criterion-v2.3.3-linux-x86_64.tar.bz2'
+    local -r file_criterion_compressed='criterion-2.4.2-linux-x86_64.tar.xz'
 
     if [ ! -d "${DEPENDENCIES_INSTALL_WORKAREA}" ] ; then
         mkdir -p ${DEPENDENCIES_INSTALL_WORKAREA}
@@ -13,15 +13,15 @@ main() {
 
     pushd ${DEPENDENCIES_INSTALL_WORKAREA}
 
-    wget https://github.com/Snaipe/Criterion/releases/download/v2.3.3/${file_criterion_compressed}
-    tar -xjvf ${file_criterion_compressed}
+    wget https://github.com/Snaipe/Criterion/releases/download/v2.4.2/${file_criterion_compressed}
+    tar -xvf ${file_criterion_compressed}
 
-    pushd criterion-v2.3.3
+    pushd criterion-2.4.2
     echo "Copying headers and library under /usr/local/"
     sudo cp --verbose --recursive include/criterion /usr/local/include/
     sudo cp --verbose --no-dereference --preserve=links \
         lib/libcriterion* /usr/local/lib/
-    popd # criterion-v2.3.3
+    popd # criterion-2.4.2
 
     popd # ${DEPENDENCIES_INSTALL_WORKAREA}
 

--- a/scripts/install_build_dependencies.sh
+++ b/scripts/install_build_dependencies.sh
@@ -19,7 +19,8 @@ main() {
     pushd criterion-v2.3.3
     echo "Copying headers and library under /usr/local/"
     sudo cp --verbose --recursive include/criterion /usr/local/include/
-    sudo cp --verbose lib/libcriterion* /usr/local/lib/
+    sudo cp --verbose --no-dereference --preserve=links \
+        lib/libcriterion* /usr/local/lib/
     popd # criterion-v2.3.3
 
     popd # ${DEPENDENCIES_INSTALL_WORKAREA}

--- a/test/utest_lenient_module.c
+++ b/test/utest_lenient_module.c
@@ -1,4 +1,7 @@
 #include <criterion/criterion.h>
+#include <criterion/new/assert.h>
+
+#include "module_wrapper.h"
 
 #if 0
 void setup(void) {

--- a/test/utest_lenient_module.c
+++ b/test/utest_lenient_module.c
@@ -11,6 +11,10 @@ void setup(void) {
 void teardown(void) {
 	    puts("Runs after the test");
 }
+
+Test(sample, passing, .signal = SIGSEGV)
+{
+}
 #endif
 
 Test(lenient_module, module_wrapper_constructor_returns_an_instance)
@@ -20,16 +24,133 @@ Test(lenient_module, module_wrapper_constructor_returns_an_instance)
     module_wrapper = NULL;
 
     module_wrapper = module_wrapper_construct_to_heap(1, 2);
-
     cr_assert(ne(module_wrapper, NULL));
 
     module_wrapper_destroy(module_wrapper);
     module_wrapper = NULL;
 }
 
-// Test(sample, passing, .signal = SIGSEGV) {
-#if 0
-Test(lenient_module, module_wrapper_destructor)
+Test(lenient_module, context_load_succeeds_for_instance_public_pointer)
 {
+    int err;
+    struct module_wrapper* module_wrapper;
+
+    err = -1;
+    module_wrapper = NULL;
+
+    module_wrapper = module_wrapper_construct_to_heap(1, 2);
+    err = module_wrapper_load_context(module_wrapper);
+    cr_expect(eq(err, 0));
+
+    module_wrapper_destroy(module_wrapper);
+    module_wrapper = NULL;
 }
-#endif
+
+Test(lenient_module, context_load_fails_for_null_pointer)
+{
+    int err;
+
+    err = -1;
+
+    err = module_wrapper_load_context(NULL);
+    cr_expect(ne(err, 0));
+}
+
+Test(lenient_module, context_load_load_result_in_fail)
+{
+    int err;
+    struct module_wrapper* module_wrapper;
+
+    err = -1;
+    module_wrapper = NULL;
+
+    module_wrapper = module_wrapper_construct_to_heap(1, 2);
+    err = module_wrapper_load_context(module_wrapper);
+    cr_assert(eq(err, 0));
+
+    err = module_wrapper_load_context(module_wrapper);
+    cr_assert(ne(err, 0));
+
+    module_wrapper_destroy(module_wrapper);
+    module_wrapper = NULL;
+}
+
+Test(lenient_module, context_load_unload_load_result_in_success)
+{
+    int err;
+    struct module_wrapper* module_wrapper;
+
+    err = -1;
+    module_wrapper = NULL;
+
+    module_wrapper = module_wrapper_construct_to_heap(1, 2);
+    err = module_wrapper_load_context(module_wrapper);
+    cr_assert(eq(err, 0));
+
+    module_wrapper_unload_context();
+    err = module_wrapper_load_context(module_wrapper);
+    cr_assert(eq(err, 0));
+
+    module_wrapper_destroy(module_wrapper);
+    module_wrapper = NULL;
+}
+
+Test(lenient_module, context_validated_to_not_be_loaded_before_load)
+{
+    int err;
+    struct module_wrapper* module_wrapper;
+
+    err = -1;
+    module_wrapper = NULL;
+
+    /*
+     * Constructed for checking that there is no side effect to context load
+     * validation.
+     */
+    module_wrapper = module_wrapper_construct_to_heap(1, 2);
+
+    err = module_wrapper_validate_context_loaded();
+    cr_assert(ne(err, 0));
+
+    module_wrapper_destroy(module_wrapper);
+    module_wrapper = NULL;
+}
+
+Test(lenient_module, context_validated_to_be_loaded_after_load)
+{
+    int err;
+    struct module_wrapper* module_wrapper;
+
+    err = -1;
+    module_wrapper = NULL;
+
+    module_wrapper = module_wrapper_construct_to_heap(1, 2);
+    err = module_wrapper_load_context(module_wrapper);
+    cr_assert(eq(err, 0));
+
+    err = module_wrapper_validate_context_loaded();
+    cr_assert(eq(err, 0));
+
+    module_wrapper_destroy(module_wrapper);
+    module_wrapper = NULL;
+}
+
+Test(lenient_module, context_validated_to_not_be_loaded_after_unload)
+{
+    int err;
+    struct module_wrapper* module_wrapper;
+
+    err = -1;
+    module_wrapper = NULL;
+
+    module_wrapper = module_wrapper_construct_to_heap(1, 2);
+    err = module_wrapper_load_context(module_wrapper);
+    cr_assert(eq(err, 0));
+
+    module_wrapper_unload_context();
+    err = module_wrapper_validate_context_loaded();
+    cr_assert(ne(err, 0));
+
+    module_wrapper_destroy(module_wrapper);
+    module_wrapper = NULL;
+}

--- a/test/utest_lenient_module.c
+++ b/test/utest_lenient_module.c
@@ -98,9 +98,11 @@ Test(lenient_module, context_load_unload_load_result_in_success)
 Test(lenient_module, context_validated_to_not_be_loaded_before_load)
 {
     int err;
+    int result;
     struct module_wrapper* module_wrapper;
 
     err = -1;
+    result = -1;
     module_wrapper = NULL;
 
     /*
@@ -109,8 +111,8 @@ Test(lenient_module, context_validated_to_not_be_loaded_before_load)
      */
     module_wrapper = module_wrapper_construct_to_heap(1, 2);
 
-    err = module_wrapper_validate_context_loaded();
-    cr_assert(ne(err, 0));
+    result = module_wrapper_is_context_loaded();
+    cr_assert(zero(i32, result));
 
     module_wrapper_destroy(module_wrapper);
     module_wrapper = NULL;
@@ -119,17 +121,19 @@ Test(lenient_module, context_validated_to_not_be_loaded_before_load)
 Test(lenient_module, context_validated_to_be_loaded_after_load)
 {
     int err;
+    int result;
     struct module_wrapper* module_wrapper;
 
     err = -1;
+    result = -1;
     module_wrapper = NULL;
 
     module_wrapper = module_wrapper_construct_to_heap(1, 2);
     err = module_wrapper_load_context(module_wrapper);
     cr_assert(eq(err, 0));
 
-    err = module_wrapper_validate_context_loaded();
-    cr_assert(eq(err, 0));
+    result = module_wrapper_is_context_loaded();
+    cr_assert(eq(i32, result, 1));
 
     module_wrapper_destroy(module_wrapper);
     module_wrapper = NULL;
@@ -138,9 +142,11 @@ Test(lenient_module, context_validated_to_be_loaded_after_load)
 Test(lenient_module, context_validated_to_not_be_loaded_after_unload)
 {
     int err;
+    int result;
     struct module_wrapper* module_wrapper;
 
     err = -1;
+    result = -1;
     module_wrapper = NULL;
 
     module_wrapper = module_wrapper_construct_to_heap(1, 2);
@@ -148,8 +154,8 @@ Test(lenient_module, context_validated_to_not_be_loaded_after_unload)
     cr_assert(eq(err, 0));
 
     module_wrapper_unload_context();
-    err = module_wrapper_validate_context_loaded();
-    cr_assert(ne(err, 0));
+    result = module_wrapper_is_context_loaded();
+    cr_assert(zero(i32, result));
 
     module_wrapper_destroy(module_wrapper);
     module_wrapper = NULL;

--- a/test/utest_lenient_module.c
+++ b/test/utest_lenient_module.c
@@ -1,0 +1,16 @@
+#include <criterion/criterion.h>
+
+#if 0
+void setup(void) {
+	    puts("Runs before the test");
+}
+
+void teardown(void) {
+	    puts("Runs after the test");
+}
+#endif
+
+Test(lenient_module, TODO_write_a_test_name)
+{
+    cr_expect(1 == 0);
+}

--- a/test/utest_lenient_module.c
+++ b/test/utest_lenient_module.c
@@ -10,7 +10,23 @@ void teardown(void) {
 }
 #endif
 
-Test(lenient_module, TODO_write_a_test_name)
+Test(lenient_module, module_wrapper_constructor_returns_an_instance)
 {
-    cr_expect(1 == 0);
+    struct module_wrapper* module_wrapper;
+
+    module_wrapper = NULL;
+
+    module_wrapper = module_wrapper_construct_to_heap(1, 2);
+
+    cr_assert(ne(module_wrapper, NULL));
+
+    module_wrapper_destroy(module_wrapper);
+    module_wrapper = NULL;
 }
+
+// Test(sample, passing, .signal = SIGSEGV) {
+#if 0
+Test(lenient_module, module_wrapper_destructor)
+{
+}
+#endif


### PR DESCRIPTION
Implementing #3 

* Add script for installing build dependencies. The only dependency for now is Criterion for unit testing. Latest release of Criterion was selected to be installed for being able to use new assertions (criterion/new/assert.h).
* Add make target `test` for running unit tests.
* Add make target `scetch` for scetching unit tests. Scetching in a Criterion test hides signals causing program termination and complicates debugging.
* In order to access functions contained in module.h macros in unit tests, a wrapper is provided.