### PR TITLE
[23] Add first negative build test to CI

### DIFF
--- a/.github/workflows/c_encapsulation_commit_gate.yml
+++ b/.github/workflows/c_encapsulation_commit_gate.yml
@@ -23,6 +23,9 @@ jobs:
     - name: Run unit tests
       run: make test
 
+    - name: Run negative build tests
+      run: ./scripts/test_builds_negative.sh
+
     - name: Build lenient encapsulation demo
       run: make out/lenient
 

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,9 @@ test: out/utest
 scetch: out/scetch
 	$<
 
+lenient_private_via_public_interface: out/lenient_private_via_public_interface
+	echo "[!] Unexpectedly compiled a program accessing private data via public interface"
+
 out/scetch: $(SRC_TEST_SCETCH) out
 	$(CC) -g $(INCLUDE_TEST) $(SRC_TEST_SCETCH) -o $@
 
@@ -37,8 +40,8 @@ out/utest: $(SRC_TEST) out
 out/lenient: $(SRC_LENIENT) out
 	$(CC) $(INCLUDE_LENIENT) $(SRC_LENIENT) -o $@
 
-out/lenient_invalid_private_access: $(SRC_LENIENT) out
-	$(CC) -DINVALID_ACCESS_TO_PRIVATE_DATA=1 $(INCLUDE_LENIENT) $(SRC_LENIENT) -o $@
+out/lenient_private_via_public_interface: $(SRC_LENIENT) out
+	$(CC) -DACCESS_PRIVATE_VIA_PUBLIC_INTERFACE=1 $(INCLUDE_LENIENT) $(SRC_LENIENT) -o $@
 
 out/lenient_memory_error_detector: $(SRC_LENIENT) out
 	$(CC) $(INCLUDE_LENIENT) -fsanitize=address $(SRC_LENIENT) -o $@

--- a/lenient/src/main.c
+++ b/lenient/src/main.c
@@ -104,7 +104,7 @@
 
 // Define:
 // * DEBUG to be 1 in compiler flags for enabling debug features.
-// * INVALID_ACCESS_TO_PRIVATE_DATA to be 1 for producing a compilation error.
+// * ACCESS_PRIVATE_VIA_PUBLIC_INTERFACE to be 1 for producing a compilation error.
 
 int main(void)
 {
@@ -137,7 +137,7 @@ int main(void)
             result);
     }
 
-#if INVALID_ACCESS_TO_PRIVATE_DATA
+#if ACCESS_PRIVATE_VIA_PUBLIC_INTERFACE
     printf("instance_demo->foo is: %d", instance_demo->foo);
 #endif
 

--- a/scripts/test_builds_negative.sh
+++ b/scripts/test_builds_negative.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -e
+
+cd $(dirname $0)
+
+readonly C_ENCAPSULATION_BASE_PATH="$(pushd ../ &> /dev/null; pwd ; popd &> /dev/null)"
+
+main() {
+    local latest_exit=0
+
+    pushd ${C_ENCAPSULATION_BASE_PATH}
+
+    echo "Building lenient encapsulation code."
+    make lenient_private_via_public_interface || latest_exit=${?}
+    if [ "0" == "${latest_exit}" ] ; then
+        echo ""
+        echo "Unexpectedly managed to build lenient encapsulation code, where "
+        echo "private data is accessed via public interface. Exiting with "
+        echo "error."
+        echo ""
+        exit 1
+    fi
+
+    popd # ${C_ENCAPSULATION_BASE_PATH}
+
+    echo "Experienced build failures where expected, exiting with success!"
+
+    exit 0
+}
+
+main "${@}"


### PR DESCRIPTION
Implementing: #23 

Verify that an attempt to access private data through public interface results in compilation error.