### PR TITLE
[22] Add test for unloading context before loading

### DIFF
--- a/test/utest_lenient_module.c
+++ b/test/utest_lenient_module.c
@@ -163,12 +163,16 @@ Test(lenient_module, context_validated_to_not_be_loaded_after_unload)
 
 Test(lenient_module, context_unload_before_load_does_not_cause_termination)
 {
+    int is_loaded;
     struct module_wrapper* module_wrapper;
 
+    is_loaded = -1;
     module_wrapper = NULL;
 
     module_wrapper = module_wrapper_construct_to_heap(1, 2);
     module_wrapper_unload_context();
+    is_loaded = module_wrapper_is_context_loaded();
+    cr_assert(zero(i32, is_loaded));
 
     module_wrapper_destroy(module_wrapper);
     module_wrapper = NULL;

--- a/test/utest_lenient_module.c
+++ b/test/utest_lenient_module.c
@@ -160,3 +160,16 @@ Test(lenient_module, context_validated_to_not_be_loaded_after_unload)
     module_wrapper_destroy(module_wrapper);
     module_wrapper = NULL;
 }
+
+Test(lenient_module, context_unload_before_load_does_not_cause_termination)
+{
+    struct module_wrapper* module_wrapper;
+
+    module_wrapper = NULL;
+
+    module_wrapper = module_wrapper_construct_to_heap(1, 2);
+    module_wrapper_unload_context();
+
+    module_wrapper_destroy(module_wrapper);
+    module_wrapper = NULL;
+}


### PR DESCRIPTION
Implementing: #22 

Check that unloading before loading does not terminate the process.