### PR TITLE
[34] Use approval-test composite action in commit gate

### DIFF
--- a/.github/actions/approval-test/action.yml
+++ b/.github/actions/approval-test/action.yml
@@ -10,15 +10,20 @@ runs:
   steps:
     - name: Setup build environment
       run: sudo ldconfig
+      shell: bash
 
     - name: Run unit tests
       run: make test
+      shell: bash
 
     - name: Run negative build tests
       run: ./scripts/test_builds_negative.sh
+      shell: bash
 
     - name: Build lenient encapsulation demo
       run: make out/lenient
+      shell: bash
 
     - name: Test lenient encapsulation demo
       run: ./scripts/test_lenient_output.sh
+      shell: bash

--- a/.github/workflows/c_encapsulation_commit_gate.yml
+++ b/.github/workflows/c_encapsulation_commit_gate.yml
@@ -17,18 +17,5 @@ jobs:
     - name: Install build dependencies
       run: ./scripts/install_build_dependencies.sh
 
-    - name: Setup build environment
-      run: sudo ldconfig
-
-    - name: Run unit tests
-      run: make test
-
-    - name: Run negative build tests
-      run: ./scripts/test_builds_negative.sh
-
-    - name: Build lenient encapsulation demo
-      run: make out/lenient
-
-    - name: Run lenient encapsulation demo
-      run: ./out/lenient
-
+    - id: call-approval-test
+      uses: ./.github/actions/approval-test


### PR DESCRIPTION
Implementing #34 

Call a previously added (in #36 ) approval-test composite action, which contains test steps to run.